### PR TITLE
Added missing done in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -31,9 +31,7 @@ for alg in $key_algorithms; do
     fi
     # ensure rights
     chmod 600 $path
-
-
- 
+done
 
 echo Add this to your \~/.tmate.conf file
 echo "set -g tmate-server-host \"${host}\""


### PR DESCRIPTION
Hey,

I've fixed the `run.sh` script whereby a `done` statement was missing.

Could you merge that back in?
Cheers.
